### PR TITLE
Add function to check multiple DLLs & use it to block archive tree character mod(s)

### DIFF
--- a/Dependencies/Common.h
+++ b/Dependencies/Common.h
@@ -2072,4 +2072,19 @@ inline bool DoesArchiveExist(std::string const& archiveName, std::set<std::strin
 	return false;
 }
 
+inline bool DoDllsExist(std::set<std::string> dllList = {})
+{
+	for (std::string const& dllName : dllList)
+	{
+		std::string dllExt = dllName + ".dll";
+		LPCWSTR dll = std::wstring(dllExt.begin(), dllExt.end()).c_str();
+
+		if (GetModuleHandle(dll) != nullptr)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
 } // namespace Common

--- a/Source/Sonic06DefinitiveExperience/Mod.cpp
+++ b/Source/Sonic06DefinitiveExperience/Mod.cpp
@@ -45,7 +45,7 @@ extern "C" __declspec(dllexport) void Init(ModInfo * modInfo)
         exit(-1);
     }
 
-    if (Common::DoesArchiveExist("Sonic.ar.00", { modInfo->CurrentMod->Name }) || Common::DoesArchiveExist("Sonic.ar.01"))
+    if (Common::DoesArchiveExist("Sonic.ar.00", { modInfo->CurrentMod->Name }) || Common::DoesArchiveExist("Sonic.ar.01") || Common::DoDllsExist({ "LinkSonic" }))
     {
         MessageBox(nullptr, TEXT("You are NOT allowed to use other character mods with this mod, please disable them."), TEXT("Sonic 06 Definitive Experience"), MB_ICONERROR);
         exit(-1);


### PR DESCRIPTION
This PR adds a new function to Common, which takes an array of dll names and checks if they are currently loaded in the game. This is useful if you want to check code mods with similar functionality without doing a long if statement.

```cpp
if (GetModuleHandle(TEXT("DLL1.dll")) != nullptr || GetModuleHandle(TEXT("DLL2.dll")) != nullptr || GetModuleHandle(TEXT("DLL3.dll")) != nullptr)
if (Common::DoDllsExist({ "DLL1", "DLL2", "DLL3" }))
```

Since this can be used to block mods that patch the archive tree, it is added to the check to block character mods in Sonic 06 Definitive Experience. It currently only hosts Link Sonic, but due to being an array future mods can easily be added to it.